### PR TITLE
fix: Update GitHub Actions to use main branch for Terraform tasks

### DIFF
--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -320,7 +320,7 @@ jobs:
 
     steps:
       - name: Terraform Validate 
-        uses: subhamay-bhattacharyya-gha/tf-validate-action@feature/GHA-0042-rename-github-action-inpu
+        uses: subhamay-bhattacharyya-gha/tf-validate-action@main
         with:
           tf-config-path: infra/${{ inputs.cloud-provider }}/tf
 
@@ -354,7 +354,7 @@ jobs:
           echo "$SNOWFLAKE_PRIVATE_KEY" | wc -l
 
       - name: Terraform Plan 
-        uses: subhamay-bhattacharyya-gha/tf-plan-action@feature/GHA-0047-add-platform-based-multi
+        uses: subhamay-bhattacharyya-gha/tf-plan-action@main
         env:
           DATABRICKS_HOST: ${{ secrets.databricks-host }}
           DATABRICKS_TOKEN: ${{ secrets.databricks-token }}
@@ -410,7 +410,7 @@ jobs:
           echo "$SNOWFLAKE_PRIVATE_KEY" | wc -l
 
       - name: Terraform Apply 
-        uses: subhamay-bhattacharyya-gha/tf-apply-action@feature/GHA-0039-add-platform-based-multi
+        uses: subhamay-bhattacharyya-gha/tf-apply-action@main
         env:
           TF_VAR_databricks_host: ${{ secrets.databricks-host }}
           TF_VAR_databricks_token: ${{ secrets.databricks-token }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Terraform deployment to use the latest stable versions of custom Terraform GitHub Actions. The main change is switching from feature branches to the `main` branch for the `tf-validate-action`, `tf-plan-action`, and `tf-apply-action` steps, ensuring more stability and consistency in the deployment pipeline.

**Workflow dependency updates:**

* Updated the `Terraform Validate` step to use `subhamay-bhattacharyya-gha/tf-validate-action@main` instead of a feature branch.
* Updated the `Terraform Plan` step to use `subhamay-bhattacharyya-gha/tf-plan-action@main` instead of a feature branch.
* Updated the `Terraform Apply` step to use `subhamay-bhattacharyya-gha/tf-apply-action@main` instead of a feature branch.